### PR TITLE
👌 IMPROVE: Contributor Bio Styles

### DIFF
--- a/src/components/Card/Contributor.js
+++ b/src/components/Card/Contributor.js
@@ -45,6 +45,7 @@ const styles = css`
       line-height: 1.25rem;
       font-weight: 300;
       color: ${GRAY_COLOR};
+      max-width: 40rem;
     }
   }
 


### PR DESCRIPTION
The contributor's page has an unlimited width available for the description. Anything beyond 600px wide is super hard to read. 

This PR fixes that.

## BEFORE ↓

![](https://on.ahmda.ws/fb12a8/url)

## AFTER ↓

![](https://on.ahmda.ws/afcbbd/url)

Looking forward, peace! ✌️

@harrysolovay I've removed the social icons CSS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
