### PR TITLE
Added ID to link

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -187,7 +187,7 @@ export default () => {
   return (
     <footer css={styles}>
       <div className='upper'>
-        <Link to={latestSlug}>
+        <Link to={latestSlug} id='latest-newsletter-link'>
           <img src={bugleGraphicSrc} alt='bugle' />
           <span>
             <Text


### PR DESCRIPTION
Simplifies fetching the latest newsletter: visitors traverse until they find the node with that `id`. Then they grab the `href`.